### PR TITLE
Fix#1: Updated and externalized TravisCI configuration + publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ install: ""
 script: 
     - "export TERM=dumb"
     - "cd guide/"
-    - "./gradlew clean aim42 publishGhPages"
+    - "./gradlew clean aim42 publish --stacktrace"
 jdk:
     - openjdk7
+env:
+  global:
+  - secure: GdFRdv4de0VTHBpFgZjw9zdYhGOtdJtCnAsND7UdVMN+3dcvx5M8UJlundGjWVzd3vW7TqNKsbEkiS16Xwjg2u6i/1nu2zR818xNNVacseIxzwa3LYmB19vf+y5eGINkMssm5MUagbT3ePcY9gAzTF0316hX59K1kHdhFC298UM=

--- a/guide/build.gradle
+++ b/guide/build.gradle
@@ -10,12 +10,10 @@ buildscript {
             url  'http://dl.bintray.com/content/aalmiray/asciidoctor'
         }
         jcenter()
-        mavenCentral()
     }
 
     dependencies {
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:0.7.0'
-        classpath 'org.ajoberstar:gradle-git:0.6.3'
     }
 }
 
@@ -36,16 +34,6 @@ asciidoctor {
             imagesdir           : 'images',
         ]
     ]
-}
-
-apply plugin: 'github-pages'
-githubPages {
-  repoUri = 'git@github.com:aim42/aim42.github.io.git'
-  pages {
-    from('build/docs')
-    from('docs')
-  }
-//  workingPath = 'build/aim42-pages'
 }
 
 
@@ -69,3 +57,7 @@ task aim42(
   
 }
 
+task publish(type: GradleBuild) {
+    buildFile = 'publish.gradle'
+    tasks = ['publishGhPages']
+}

--- a/guide/publish.gradle
+++ b/guide/publish.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'org.ajoberstar:gradle-git:0.6.3'
+    }
+}
+
+
+apply plugin: 'github-pages'
+githubPages {
+  repoUri = 'https://github.com/aim42/aim42.github.io.git'
+  pages {
+    from('docs')
+  }
+  credentials {
+    username = System.getenv('GH_TOKEN')
+    password = ''
+  }
+}
+


### PR DESCRIPTION
Fixed #1. Guide can now be created and published via `./gradlew aim42 publish`. Travis-CI integration is tested but needs to be enabled by @gernotstarke.
