### PR TITLE
Unified names of patterns for analysis

### DIFF
--- a/guide/src/asciidoc/analyze.adoc
+++ b/guide/src/asciidoc/analyze.adoc
@@ -22,10 +22,10 @@ Systematically look for such issues at various places and with various people.
 TIP: To effectively find issues, you need an appropriate amount of _understanding_ of the system under design (<<SuD>>), its technical concepts, code-structure, inner workings, major external interfaces and its development process.
 
 
-. Start <<capture-quality-requirements, capturing current quality requirements>> from the _authoritative_ stakeholders of the systems.
-. Conduct a <<Qualitative-Analysis,qualitative analysis>> of the system, its architecture and surrounding organization, based upon the specific quality requirements 
+. Start <<Capture-Quality-Requirements, capturing current quality requirements>> from the _authoritative_ stakeholders of the systems.
+. Conduct a <<Qualitative-Analysis, qualitative analysis>> of the system, its architecture and surrounding organization, based upon the specific quality requirements 
 . Perform <<Static-Code-Analysis, static code analysis>>
-. Conduct <<Stakeholder-Interviews, stakeholder interviews>>
+. Conduct <<Stakeholder-Interview, stakeholder interviews>>
 . Perform a number of *runtime analysis*, e.g. performance and load monitoring, process and thread analysis
 . Inspect the data created, modified and queried by the system, for structure, size, volume or specialities
 . Inspect and analyze all involved organizational processes
@@ -40,29 +40,30 @@ WARNING: Never start solving problems until you have a thourough understanding o
 === Patterns and Practices for Analysis
 (given in alphabetical order)
 
-* Architecture Analysis, see <<Qualitative-Analysis>> and <<ATAM>>
-* <<ATAM>>
+* Architecture Analysis, see <<Qualitative-Analysis>> and <<ATAM, ATAM>>
+* <<ATAM, ATAM>>
 * <<Capture-Quality-Requirements>>
-* <<Context-Analysis>>
-* <<Data-Analysis>>
+* <<Context-Analysis, Context Analysis>>
+* <<Data-Analysis, Data Analysis>>
 * <<Debugging>>
-* <<Development-Process-Analysis>>
-* <<Documentation-Analysis>>
-* <<Issue-Tracker-Analysis>>
-* <<Profiling>>
+* <<Development-Process-Analysis, Development Process Analysis>>
+* <<Documentation-Analysis, Documentation Analysis>>
+* <<Issue-Tracker-Analysis, Issue Tracker Analysis>>
+* <<Profiling, Profiling>>
 * <<Qualitative-Analysis>>
-* <<Quantitative-Analysis>>
+* <<Quantitative-Analysis, Quantitative Analysis>>
 * <<Questionnaire>>, especially <<Pre-Interview-Questionnaire>>
-* <<Requirements-Analysis>>
+* <<Requirements-Analysis, Requirements Analysis>>
 * <<Root-Cause-Analysis, Root Cause Analysis>> - finding the root-cause of problems
-* <<Runtime-Artifact-Analysis>> 
+* <<Runtime-Artifact-Analysis, Runtime Artifact Analysis>> 
 * <<Separate-Cause-From-Effect, Separate Cause From Effect>>
-* <<Software-Archaeology, Software Archeology>>
-* <<Stakeholder-Analysis>>
-* <<Stakeholder-Interview>>, see also <<pre-interview-questionnaire, pre-interview questionnaire>>.
-* <<Static-Code-Analysis>> (Structural analysis)
+* <<Software-Archeology>>
+* <<Stakeholder-Analysis, Stakeholder Analysis>>
+* <<Stakeholder-Interview, Stakeholder Interview>>, see also <<Pre-Interview-Questionnaire>>.
+* <<Static-Code-Analysis>>
+* <<Structural-Analysis, Structural (Code) Analysis>>
 * <<Take-What-They-Mean, Take What They Mean>> (not what they say, as it may differ).
-* <<Use-Case-Cluster>>
+* <<Use-Case-Cluster, Use Case Cluster>>
 * <<View-Based-Understanding, View Based Understanding>>
 
 

--- a/guide/src/asciidoc/pattern-index.adoc
+++ b/guide/src/asciidoc/pattern-index.adoc
@@ -44,7 +44,7 @@ Category: <<Improve>>
 
 . *<<Capture-Quality-Requirements, Capture Quality Requirements>>*
 +
-Part of <<ATAM>>, Capture and document specific quality requirements. Specialisation of <<Requirements-Analysis>>. 
+Part of <<ATAM>>, Capture and document specific quality requirements. Specialisation of <<Requirements-Analysis, Requirements Analysis>>. 
 Category: <<Analyze>>
 +
 
@@ -72,7 +72,7 @@ Category: <<Crosscutting>>
 
 . [[Context-Analysis]]
 Context Analysis:: Analyse external interfaces for risk, technology, business value and other factors.
-Category: <<Evaluate>>
+Category: <<Analyze>>
 +
 
 . [[Data-Analysis]]
@@ -205,7 +205,7 @@ Category: <<Crosscutting>>
 . [[Instrument-System]]
 Instrument-System:: Instrument either the executable or the source code to make 
 <<Explicit-Assumption, assumtions explicit>> and expand on <<runtime analysis>> and 
-<<runtime artifact analysis>>. 
+<<Runtime-Artifact-Analysis, Runtime Artifact Analysis>>. 
 Category: <<Analyze>>
 +
 
@@ -280,7 +280,7 @@ Performance Analysis::
 Category: <<Analyze>>
 +
 
-. *<<Pre-Interview-Questionnaire>>*
+. *<<Pre-Interview-Questionnaire, Pre Interview Questionnaire>>*
 +
 Prior to interviewing stakeholders, present them with a written questionnaire, so they can reflect in advance. A specialisation of <<Questionnaire>>.
 Category: <<Analyze>>
@@ -347,9 +347,9 @@ Category: <<Analyze>>
 +
 
 . [[Runtime-Artifact-Analysis]]
-Runtime-Artifact Analysis:: (aka Log-Analysis, Trace-Analysis, Protocol-Analysis) Inspect artifacts created at runtime (e.g. logfiles, protocolls, system-traces) for information about problems, root-causes or system behavior.
+Runtime Artifact Analysis:: (aka Log-Analysis, Trace-Analysis, Protocol-Analysis) Inspect artifacts created at runtime (e.g. logfiles, protocolls, system-traces) for information about problems, root-causes or system behavior.
 Category: <<Analyze>>
-// TODO: perhaps Log-Anasysis deserves a separate entry? Especially in security
+// TODO: perhaps Log-Analysis deserves a separate entry? Especially in security
 // sensitiv environments? MM 2014-03-16 
 +
 
@@ -368,7 +368,7 @@ Separate Cause from Effect:: See <<Root-Cause-Analysis>>
 Category: <<Analyze>>
 +
 
-. *<<Software-Archeology>>*
+. *<<Software-Archeology, Software Archeology>>*
 +
 Understand software by analysing its source code, usually in absence of other documentation or knowledge sources.  
 Category: <<Evaluate>>
@@ -423,7 +423,7 @@ Category: <<Improve>>
 
 
 . [[Use-Case-Cluster]]
-Use-Case Cluster:: Understand system functionality by grouping functionality into clusters to reduce complexity.
+Use Case Cluster:: Understand system functionality by grouping functionality into clusters to reduce complexity.
 Category: <<Analyze>>
 +
 

--- a/guide/src/asciidoc/patterns/analyze/capture-quality-requirements.adoc
+++ b/guide/src/asciidoc/patterns/analyze/capture-quality-requirements.adoc
@@ -58,7 +58,7 @@ If you have well-documented, specific and current (!) quality requirements avail
 * <<ATAM>>
 * <<Explicit-Assumption>>
 * <<Qualitative-Analysis>>
-* <<Requirements-Analysis>>
+* <<Requirements-Analysis, Requirements Analysis>>
 
 ==== References
 

--- a/guide/src/asciidoc/patterns/analyze/pre-interview-questionnaire.adoc
+++ b/guide/src/asciidoc/patterns/analyze/pre-interview-questionnaire.adoc
@@ -1,5 +1,5 @@
 [[Pre-Interview-Questionnaire]]
-=== Pre-Interview Questionnaire 
+=== Pre Interview Questionnaire 
 
 ==== Intent
 Prior to interviewing stakeholders, present them with a written questionnaire, so they can reflect in advance. 
@@ -18,8 +18,8 @@ Mix open and closed questions:
 
 Include a "Comments/Remarks" section at the end of the questionnaire, so stakeholders can comment on topics you did not consider in advance.
 
-The pre-interview questionnaire shall be handed over to the appropriate stakeholders in advance, a few days before the interview.
-
+The <<Pre-Interview-Questionnaire, Pre Interview Questionnaire>> shall be handed over to the appropriate stakeholders in advance, a few days before the interview.
+    
 As these documents will be read and processed by external and potentially critical stakeholders, you need to care for several details:
 
 * stakeholder specific terminology: Ensure your questions will be understandable by the target audience. See <<Stakeholder-Specific-Communication, stakeholder-specific communication>>
@@ -40,6 +40,6 @@ TODO: add EN sample for download (https://github.com/aim42/aim42/issues/20)
 
 
 ==== Related Patterns
-* <<stakeholder-interview, Stakeholder interview>>
+* <<Stakeholder-Interview, Stakeholder Interview>>
 * <<Questionnaire>>
 

--- a/guide/src/asciidoc/patterns/analyze/software-archeology.adoc
+++ b/guide/src/asciidoc/patterns/analyze/software-archeology.adoc
@@ -32,8 +32,8 @@ You have to understand a system with
 
 ==== Related Patterns
 * Code Reading
-* <<Runtime-Artifact-Analysis>>
-* Structural Analysis
+* <<Runtime-Artifact-Analysis, Runtime Artifact Analysis>>
+* <<Structural-Analysis, Structural (Code) Analysis>>
 
 
 ==== References

--- a/guide/src/asciidoc/patterns/analyze/static-analysis.adoc
+++ b/guide/src/asciidoc/patterns/analyze/static-analysis.adoc
@@ -34,7 +34,7 @@ Apply static code analysis when the code base is medium sized or large and the a
 
 ==== Related Patterns
 * <<Software-Archeology>>
-* <<Structural-Analysis>>
+* <<Structural-Analysis, Structural (Code) Analysis>>
 
 
 ==== References

--- a/guide/src/asciidoc/patterns/analyze/take-what-they-mean.adoc
+++ b/guide/src/asciidoc/patterns/analyze/take-what-they-mean.adoc
@@ -23,8 +23,8 @@ Apply this pattern whenever you communicate to other people (aka stakeholders).
 
 
 ==== Related Patterns
-* In every <<Stakeholder-Interview>> you should apply this pattern. 
-* <<Stakeholder-Analysis>> to find out, who are the important stakeholders you should apply this pattern to.
+* In every <<Stakeholder-Interview, Stakeholder Interview>> you should apply this pattern. 
+* <<Stakeholder-Analysis, Stakeholder Analysis>> to find out, who are the important stakeholders you should apply this pattern to.
 
 ==== References
 Special thanx to Phillip Ghadir (who is too humble to claim this discovery) for giving this pattern its name. 


### PR DESCRIPTION
The pattern names are now written without a hyphen.
Fixed links of some patterns.
Fixed category of a pattern.
