### PR TITLE
escape docdate attribute

### DIFF
--- a/src/main/asciidoc/appendices/asciidoc-help.adoc
+++ b/src/main/asciidoc/appendices/asciidoc-help.adoc
@@ -153,8 +153,10 @@ Files are included with the "include" directive:
 
 === Attributes
 Some attributes are useful, e.g.
-
-* `{docdate}` will insert the last modification data (here: {docdate})
+----
+{docdate}
+----
+will insert the last modification data (here: {docdate})
 
 === Footnotes
 In case you need a footnote - that's easy too:


### PR DESCRIPTION
Otherwise the rendered version does not show the necessary markup, but only the result.