### PR TITLE
Fix all kinds of references and links (except one)

### DIFF
--- a/graphics/02-analyze/analyze-patterns-complete.graffle
+++ b/graphics/02-analyze/analyze-patterns-complete.graffle
@@ -1420,7 +1420,7 @@ Analysis}</string>
 			<key>Link</key>
 			<dict>
 				<key>url</key>
-				<string>#Collect-Improvement-Opportunities</string>
+				<string>#Collect-Opportunities-For-Improvement</string>
 			</dict>
 			<key>Style</key>
 			<dict>

--- a/graphics/02-analyze/analyze-patterns-overview.graffle
+++ b/graphics/02-analyze/analyze-patterns-overview.graffle
@@ -862,7 +862,7 @@ Analysis}</string>
 					<key>Link</key>
 					<dict>
 						<key>url</key>
-						<string>#Collect-Improvement-Opportunities</string>
+						<string>#Collect-Opportunities-For-Improvement</string>
 					</dict>
 					<key>Style</key>
 					<dict>
@@ -2454,7 +2454,7 @@ Analysis}</string>
 					<key>Link</key>
 					<dict>
 						<key>url</key>
-						<string>#Collect-Improvement-Opportunities</string>
+						<string>#Collect-Opportunities-For-Improvement</string>
 					</dict>
 					<key>Style</key>
 					<dict>

--- a/graphics/05-crosscutting/crosscutting-patterns-complete.graffle
+++ b/graphics/05-crosscutting/crosscutting-patterns-complete.graffle
@@ -728,7 +728,7 @@ cost}</string>
 			<key>Link</key>
 			<dict>
 				<key>url</key>
-				<string>#Plan-Improvement</string>
+				<string>#Plan-Improvements</string>
 			</dict>
 			<key>Style</key>
 			<dict>

--- a/graphics/05-crosscutting/crosscutting-patterns-overview.graffle
+++ b/graphics/05-crosscutting/crosscutting-patterns-overview.graffle
@@ -639,7 +639,7 @@ cost}</string>
 			<key>Link</key>
 			<dict>
 				<key>url</key>
-				<string>#Plan-Improvement</string>
+				<string>#Plan-Improvements</string>
 			</dict>
 			<key>Style</key>
 			<dict>

--- a/src/main/asciidoc/about.adoc
+++ b/src/main/asciidoc/about.adoc
@@ -30,7 +30,7 @@ image:https://img.shields.io/travis/aim42/aim42/master.svg[link="https://travis-
 image:https://img.shields.io/github/issues/aim42/aim42.svg[link="https://github.com/aim42/aim42/issues",window="_blank", alt="nr-of-issues:unknown"]
 image:https://img.shields.io/github/stars/aim42/aim42.svg[link="https://github.com/aim42/aim42",window="_blank", alt="github-stars"]
 image:https://img.shields.io/github/contributors/aim42/aim42.svg[link="https://github.com/aim42/aim42",window="_blank", alt="github-contributors"]
-image:https://img.shields.io/twitter/follow/gernotstarke.svg?style=social&label=Followers[link="https://twitter.com/gernotstarke",window="_blank", alt=""]
+image:https://img.shields.io/twitter/follow/gernotstarke.svg?style=social&label=Followers[link="https://twitter.com/gernotstarke",window="_blank", alt="Twitter follower button"]
 
 === About this documentation
 This document serves as the _method reference_ - it collects practices and patterns.

--- a/src/main/asciidoc/aim42_introduction.adoc
+++ b/src/main/asciidoc/aim42_introduction.adoc
@@ -91,8 +91,8 @@ image::aim42-phases.png["aim42 phases", title="Three Phases of aim42"]
 
 . <<Improve>>: systematically improve code and structures, reduce technical debt, remove waste and optimize.
 
-These three phases are performed iteratively - as explained <<Iterative-Approach ,below>>.
-Several <<Crosscutting, cross-cutting practices and patterns>> should be applied in all phases, for example documenting results, <<collect-opportunities-for-improvement>>
+These three phases are performed iteratively - as explained <<Iterative-Approach,below>>.
+Several <<Crosscutting, cross-cutting practices and patterns>> should be applied in all phases, for example documenting results, <<Collect-Opportunities-For-Improvement>>
 or long- and short-term planning activities.
 
 

--- a/src/main/asciidoc/analyze.adoc
+++ b/src/main/asciidoc/analyze.adoc
@@ -37,7 +37,7 @@ One serious risk in this phase is a premature restriction to certain artifacts o
 <img border=0 src="images/analyze-patterns-overview.png" usemap="#AnalysisOverview" alt="analyze-patterns overview">
 <map name="AnalysisOverview">
 	<area shape=rect coords="262,281,366,340" href="#Development-Process-Analysis">
-	<area shape=rect coords="457,118,576,178" href="#Collect-Improvement-Opportunities">
+	<area shape=rect coords="457,118,576,178" href="#Collect-Opportunities-For-Improvement">
 	<area shape=rect coords="194,401,291,450" href="#Collect-Issues">
 	<area shape=rect coords="3,301,126,350" href="#Quantitative-Analysis">
 	<area shape=rect coords="263,141,382,190" href="#Stakeholder-Interview">
@@ -82,7 +82,7 @@ WARNING: Never start solving problems until you have a thorough understanding of
 	<area shape=rect coords="93,690,175,729" href="#Instrument-System">
 	<area shape=rect coords="196,590,299,629" href="#Infrastructure-Analysis">
 	<area shape=rect coords="294,319,398,379" href="#Development-Process-Analysis">
-	<area shape=rect coords="610,97,729,156" href="#Collect-Improvement-Opportunities">
+	<area shape=rect coords="610,97,729,156" href="#Collect-Opportunities-For-Improvement">
 	<area shape=rect coords="305,508,402,557" href="#Collect-Issues">
 	<area shape=rect coords="28,803,125,852" href="#Static-Code-Analysis">
 	<area shape=rect coords="358,690,449,739" href="#Software-Archeology">
@@ -127,6 +127,9 @@ include::patterns/analyze/development-process-analysis.adoc[]
 include::patterns/analyze/documentation-analysis.adoc[]
 
 include::patterns/analyze/infrastructure-analysis.adoc[]
+
+
+include::patterns/analyze/hierarchical-quality-model.adoc[]
 
 include::patterns/analyze/instrument-system.adoc[]
 

--- a/src/main/asciidoc/appendices/bibliography.adoc
+++ b/src/main/asciidoc/appendices/bibliography.adoc
@@ -1,8 +1,8 @@
 :numbered!:
 
-[[bibliography]]
 [appendix]
 == Bibliography
+[bibliography]
 
 * [[[arc42]]] arc42: Resources for Software Architects. Practical template, liberal licence.
 Available in a variety of formats, see http://arc42.de[German website] or http://arc42.org[English website].

--- a/src/main/asciidoc/appendices/bibliography.adoc
+++ b/src/main/asciidoc/appendices/bibliography.adoc
@@ -16,7 +16,7 @@ they sometimes spend too much time tracking too little bugs.
 
 * [[[Annett-Legacy]]] Robert Annett: Working with Legacy Systems: A practical guide to the real systems we inherit.  http://leanpub.com/WorkingWithLegacySystems[Leanpub Publishing].
 
-* [[Brown]] William J. Brown: AntiPatterns: Refactoring Software,
+* [[[Brown]]] William J. Brown: AntiPatterns: Refactorsing Software,
 Architecture and Projects in Crisis, John Wiley & Sons, 1998 -- a tried and
 true work on things that tend to go wrong in software development and other
 projects.

--- a/src/main/asciidoc/appendices/bibliography.adoc
+++ b/src/main/asciidoc/appendices/bibliography.adoc
@@ -16,7 +16,7 @@ they sometimes spend too much time tracking too little bugs.
 
 * [[[Annett-Legacy]]] Robert Annett: Working with Legacy Systems: A practical guide to the real systems we inherit.  http://leanpub.com/WorkingWithLegacySystems[Leanpub Publishing].
 
-* [[[Brown]]] William J. Brown: AntiPatterns: Refactorsing Software,
+* [[[Brown]]] William J. Brown: AntiPatterns: Refactoring Software,
 Architecture and Projects in Crisis, John Wiley & Sons, 1998 -- a tried and
 true work on things that tend to go wrong in software development and other
 projects.

--- a/src/main/asciidoc/crosscutting.adoc
+++ b/src/main/asciidoc/crosscutting.adoc
@@ -3,7 +3,7 @@
 [[Crosscutting]]
 == Cross-Cutting Practices and Patterns
 
-image::01-intro-and-overview/crosscutting-phase.png["", title="Crosscutting-Phase"]
+image::01-intro-and-overview/crosscutting-phase.png["", title="Crosscutting-Phase", alt="Visualization of the crosscutting phase"]
 
 === Goals
 
@@ -23,7 +23,7 @@ to be done.
 </map>
 
 <img border=0 src="images/crosscutting-patterns-overview.png"
-usemap="#CrosscuttingPracticesOverview">
+usemap="#CrosscuttingPracticesOverview", alt="Overview of the crosscutting patterns">
 ++++
 
 === How it works
@@ -68,7 +68,7 @@ image::issues-and-improvements.png[title="Collect issues and improvements", id="
 ++++
 <map name="CrosscuttingPractices">
    	<area shape=poly coords="52,443,133,443,139,446,139,444,142,447,142,446,145,449,145,488,139,491,59,491,52,489,49,488,46,485,46,446,52,443" href="#Goals-Constraints">
-	<area shape=rect coords="302,477,412,526" href="#Plan-Improvement">
+	<area shape=rect coords="302,477,412,526" href="#Plan-Improvements">
 	<area shape=rect coords="11,204,91,238" href="#Widen-Your-Options">
 	<area shape=rect coords="286,82,385,116" href="#Architectural-Understanding">
 	<area shape=poly coords="215,375,295,375,301,378,301,377,305,380,305,378,308,381,308,420,301,423,221,423,215,422,212,420,209,417,209,378,215,375" href="#Issue-List">
@@ -86,7 +86,7 @@ image::issues-and-improvements.png[title="Collect issues and improvements", id="
 
 </map>
 
-<img border=0 src="images/crosscutting-patterns-complete.png" usemap="#CrosscuttingPractices">
+<img border=0 src="images/crosscutting-patterns-complete.png" usemap="#CrosscuttingPractices", alt="Overview of the crosscutting practices">
 ++++
 
 
@@ -100,7 +100,7 @@ You should look for improvement opportunities, remedies, measures,
 tactics and strategies in all of the aim42-phases.
 
 
-// TODO: rename the figure to collect-opportunities-for-improvement
+// TODO: rename the figure to Collect-Opportunities-For-Improvement
 [[figure-collect-remedies]]
 image::collect-remedies.png["collect remedies", title="Collect Remedies in All Phases"]
 
@@ -108,7 +108,7 @@ image::collect-remedies.png["collect remedies", title="Collect Remedies in All P
 [[Collect-Issues]]
 === [pattern]#Collect Issues#
 You should constantly watch out for issues (problems and risks), especially
-during <<Analyze, analysis>> activities like <<Stakeholder-Interviews>> and others.
+during <<Analyze, analysis>> activities like <<Stakeholder-Interview>> and others.
 
 The artifact (physical collection) is the <<Issue-List>>.
 

--- a/src/main/asciidoc/evaluate.adoc
+++ b/src/main/asciidoc/evaluate.adoc
@@ -62,10 +62,10 @@ concerned by the problem, we count their number.
 	<area shape=rect coords="346,3,425,62" href="#Estimate-In-Interval">
 	<area shape=rect coords="533,3,653,62" href="#Estimate-Improvement-Cost">
 	<area shape=rect coords="147,3,251,62" href="#Estimate-Issue-Cost">
-	<area shape=rect coords="482,150,618,199" href="#collect-opportunities-for-improvement">
+	<area shape=rect coords="482,150,618,199" href="#Collect-Opportunities-For-Improvement">
 	<area shape=rect coords="200,145,297,193" href="#Collect-Issues">
 </map>
-<img border=0 src="images/evaluate-patterns-conceptmap.png" usemap="#EvaluationPractices">
+<img border=0 src="images/evaluate-patterns-conceptmap.png" usemap="#EvaluationPractices", alt="concept map of the evaluate patterns">
 ++++
 
 

--- a/src/main/asciidoc/improve.adoc
+++ b/src/main/asciidoc/improve.adoc
@@ -6,7 +6,7 @@ image::01-intro-and-overview/improve-phase.png["improve-phase", title="Improve-P
 
 === Goals
 
-. Execute and coordinate the improvement activities to eliminate problems and issues found during <<Analyze, analysis>>. There is a whole <<improve-practices, bunch of practices>> devoted to this step, and we described the different  <<improve-approaches, approaches>> you can take to run the improvements.
+. Execute and coordinate the improvement activities to eliminate problems and issues found during <<Analyze, analysis>>. There is a whole <<improve-practices, bunch of practices>> devoted to this step, and we described the different  <<improve-approaches-overview, approaches>> you can take to run the improvements.
 
 . Apply selected opportunities for improvement
 
@@ -27,13 +27,13 @@ image::improve-fundamentals-approaches-practices.png["improve-concepts", title="
 <<improve-fundamentals, Fundamentals>>:: Some principles which you should consider
 whatever steps you take on your road to improvement.
 
-<<improve-approaches, Approaches>>:: Overall (strategic, long-term) decisions how to
+<<improve-approaches-overview, Approaches>>:: Overall (strategic, long-term) decisions how to
 tackle improvement, structured in several categories. Start with the <<improve-approaches-overview, overview>>
 or jump right to the <<improve-approaches-details, details>>.
 
 <<improve-practices, Practices>>:: fine-grained practices or patterns, structured in
 several categories. Start with the <<improve-practices-overview, overview>> or jump
-right to the <<improve-practices-details, details>>.
+right to the <<improve-approaches-details, details>>.
 
 
 We'll cover these topics in a top-down manner, starting with a brief overview of the respective

--- a/src/main/asciidoc/pattern-index.adoc
+++ b/src/main/asciidoc/pattern-index.adoc
@@ -112,9 +112,9 @@ Category: <<Analyze>>
 +
 
 
-. *<<Deprecate-Obsolete-Parts>>*
+. [[Deprecate-Obsolete-Parts]]
 +
-
+[pattern]#Deprecate Obsolete Parts#:: Actively mark parts in software that aren't needed anymore and communicate to your consumers or customers, that you will remove specific functionality in the future.
 Category: <<Improve>>
 +
 

--- a/src/main/asciidoc/pattern-index.adoc
+++ b/src/main/asciidoc/pattern-index.adoc
@@ -19,7 +19,8 @@ Category: <<Crosscutting>>
 +
 
 . [[Architecture-Backlog]]
-[pattern]#Architecture-Backlog#:: Keep a prioritized list of improvement tasks (_remedies_) with their as a backlog, parallel to the (regular) feature backlog.
+[pattern]#Architecture-Backlog#::
+Keep a prioritized list of improvement tasks (_remedies_) with their as a backlog, parallel to the (regular) feature backlog.
 Category: <<Improve>>
 +
 
@@ -78,7 +79,7 @@ Category: <<Improve>>
 +
 
 
-. *<<collect-opportunities-for-improvement>>*
+. *<<Collect-Opportunities-For-Improvement>>*
 +
 Keep a list of possible and potential measures, remedies, tactics, strategies for improvements. Regularly match those to your <<Collect-Issues, collection of issues>>.
 Category: <<Crosscutting>>
@@ -86,7 +87,7 @@ Category: <<Crosscutting>>
 
 . *<<Collect-Issues>>*
 +
-Keep a list of problems, issues and risks. Regularly match those to your <<collect-opportunities-for-improvement, collection of possible remedies>>.
+Keep a list of problems, issues and risks. Regularly match those to your <<Collect-Opportunities-For-Improvement, collection of possible remedies>>.
 Category: <<Crosscutting>>
 
 
@@ -132,7 +133,8 @@ Category: <<Analyze>>
 
 
 . [[Document-Problems]]
-[pattern]#Document Problems#:: See <<improvement-backlog, Improvement Backlog>>.
++
+[pattern]#Document Problems#:: See <<Improvement-Backlog, Improvement Backlog>>.
 Category: <<Crosscutting>>
 +
 
@@ -162,6 +164,7 @@ Category: <<Evaluate>>
 +
 
 . *<<Expect-Denial>>*
++
 Some people will oppose your findings, will whitewash or sugarcoat issues, problems or <<Root-Cause-Analysis, root causes>>. Regardless on how careful you prepared your analysis, they will try to diminish or attack your findings. Category: <<Crosscutting>>
 +
 
@@ -210,7 +213,9 @@ Decompose the overall goal of "high quality" into more detailed and precise requ
 Category: <<Analyze>>
 +
 
-. *<<Impact-Analysis>>*:: Determine what impact (in code, concepts and
+. *<<Impact-Analysis>>*
++
+Determine what impact (in code, concepts and
   the organization) a specific action (e.g. refactoring) will or might have.
 Category: <<Crosscutting>>
 +
@@ -295,9 +300,9 @@ Simplify the interaction of a client with a set of service components.
 Category: <<Improve>>
 +
 
-
-. [[Measure]]
-[pattern]#Measure#:: Gather various metrics and visualize them on dashboards in order to make your system behavior more predictable and assumed coincidences explainable. Examples of such metrics are thread pool saturation, number of failed logins, requests per second but also number of successful orders today, amount-of-time-spent-debugging-this-component, code-metrics, amount-of-effort-needed-for-feature...
+. *<<Measure>>*
++
+Gather various metrics and visualize them on dashboards in order to make your system behavior more predictable and assumed coincidences explainable. Examples of such metrics are thread pool saturation, number of failed logins, requests per second but also number of successful orders today, amount-of-time-spent-debugging-this-component, code-metrics, amount-of-effort-needed-for-feature...
 Category: <<Improve>>
 +
 
@@ -354,7 +359,7 @@ Category: <<Analyze>>
 
 . *<<Qualitative-Analysis>>*
 +
-Analyze which quality goals of the <<System>> are at risk and which are met by the current implementation. Needs concrete <<Quality-Requirements>>. See <<Atam>>
+Analyze which quality goals of the <<System>> are at risk and which are met by the current implementation. Needs concrete <<Quality-Requirements>>. See <<ATAM>>.
 Category: <<Analyze>>
 +
 

--- a/src/main/asciidoc/pattern-index.adoc
+++ b/src/main/asciidoc/pattern-index.adoc
@@ -411,7 +411,13 @@ Category: <<Analyze>>
 
 . *<<Runtime-Analysis>>*
 +
-Analyze the runtime behavior of the <<System>>, e.g. with respect to time and resource consumption or creation. See <<Profiling>>, <<Performance-Analysis>> and <<Runtime-Artifact-Analysis>>.
+Analyze the runtime behavior of the <<System>>, e.g. with respect to time and resource consumption or creation.
+Category: <<Analyze>>
++
+
+. [[Runtime-Artifact-Analysis]]
+[pattern]#Runtime Artifact Analysis#::
+Artifacts that were created by a running system are a gold mine. They allow you to get a deeper understanding of the inner workings of a software system. Use log management, aggregators and monitoring tools to gather log files. Then analyze usage patterns, stack traces or errors to see what the system is really doing.
 Category: <<Analyze>>
 +
 

--- a/src/main/asciidoc/patterns/analyze/instrument-system.adoc
+++ b/src/main/asciidoc/patterns/analyze/instrument-system.adoc
@@ -6,9 +6,7 @@
 
 Use retroactive modification of the executables which target
 cross-cutting concerns to make the existing software-base tell about it's
-internals. Ways to achieve this can include <<Aspect-Oriented-Programming,
-Aspect Oriented Programming (AOP)>>, <<Monkey-Patching, Monkey Patching>> and
-other <<meta-programming, meta programming>> techniques.
+internals. Ways to achieve this can include https://en.wikipedia.org/wiki/Aspect-oriented_programming[aspect-oriented programming (AOP)], https://en.wikipedia.org/wiki/Monkey_patch[Monkey-Patching] and other https://en.wikipedia.org/wiki/Metaprogramming[metaprogramming] techniques.
 
 ===== Intent
 
@@ -66,7 +64,7 @@ original non-instrumented version.
 
 ===== Applicability
 The pattern is almost universally applicable as long as there is a way to
-introduce instrumentation to the executable and <<operations>> can be
+introduce instrumentation to the executable and the operations team can be
 convinced that it is possible to switch back from the instrumented version
 real fast.
 

--- a/src/main/asciidoc/patterns/analyze/view-based-understanding.adoc
+++ b/src/main/asciidoc/patterns/analyze/view-based-understanding.adoc
@@ -40,10 +40,10 @@ and reason about the code structure
 * high-level overview
 
 ===== Related Patterns
-* <<Architecture-Documentation>>
+* <<Doc-As-Code>>
 * <<Context-Analysis>>
 
 ===== References
 
 * <<arc42>>
-* Kruchten
+* https://en.wikipedia.org/wiki/4%2B1_architectural_view_model[4+1 architectural view model] by Philippe Kruchten

--- a/src/main/asciidoc/patterns/crosscutting/architectural-understanding.adoc
+++ b/src/main/asciidoc/patterns/crosscutting/architectural-understanding.adoc
@@ -13,7 +13,7 @@ to _locate_ issues, risks and opportunities for improvement.
 * Business or technical system context, with external interfaces. Learn this
   from <<Context-Analysis>> or <<Infrastructure-Analysis>>.
 
-* Solution strategy, often to be learnt from <<Stakeholder-Interviews>> with
+* Solution strategy, often to be learnt from <<Stakeholder-Interview>> with
   experienced developers of the system.
 
 * Building block structure, the static organization of the source code. 

--- a/src/main/asciidoc/patterns/crosscutting/crosscutting-patterns-complete/plan-improvement.adoc
+++ b/src/main/asciidoc/patterns/crosscutting/crosscutting-patterns-complete/plan-improvement.adoc
@@ -4,5 +4,5 @@
 Conduct long- and short-term planning of improvement activities. Balance
 or align issues and improvements, considering existing goals and constraints.
 
-Consists of long-term decisions (concerning <<improve-approaches>>) and
+Consists of long-term decisions (concerning <<improve-approaches-overview>>) and
 short-term planning.

--- a/src/main/asciidoc/patterns/crosscutting/expect-denial.adoc
+++ b/src/main/asciidoc/patterns/crosscutting/expect-denial.adoc
@@ -49,7 +49,7 @@ In case you encounter minimization or resistance, get support from the highest m
 
 . *Hostility*, or "_Shoot the messenger_". Always remain calm and polite - but hard in your argumentation and facts. Hostile stakeholders can rarely be convinced of something, but need to be handled with diplomacy, politics and organizational skills (none of which we can cover here).
 +
-Be prepared for _hostile actions_, though: In case of critical issues, always keep details documentation of their origin. Be prepared to _proof_ those issues, remove even minor omissions or formal weaknesses in your argumentation. Your issues and <<Root-Cause-Analysis>> has to be flawless and backed by meticulous research and management support. Ensure <<Traceability>> of your chain of reasoning! Keep written records of <<Stakeholder-Interviews>> and of suspicious pieces of source code or documentation.
+Be prepared for _hostile actions_, though: In case of critical issues, always keep details documentation of their origin. Be prepared to _proof_ those issues, remove even minor omissions or formal weaknesses in your argumentation. Your issues and <<Root-Cause-Analysis>> has to be flawless and backed by meticulous research and management support. Ensure <<Traceability>> of your chain of reasoning! Keep written records of <<Stakeholder-Interview>> and of suspicious pieces of source code or documentation.
 
 Let others review your findings before publication.
 

--- a/src/main/asciidoc/patterns/crosscutting/improvement-backlog.adoc
+++ b/src/main/asciidoc/patterns/crosscutting/improvement-backlog.adoc
@@ -6,7 +6,7 @@ Keep a public, written backlog of possible improvements, remedies, tactics or st
 
 * Revise this backlog in regular intervalls.
 * Define the _owner role_ for this backlog, similar to the _product owner_ in Scrum.
-* Enhance the backlog with information from the <<evaluation>> phase, like cost, effort or risk.
+* Enhance the backlog with information from the <<Evaluate>> phase, like cost, effort or risk.
 
 
 [[figure-improvement-backlog]]

--- a/src/main/asciidoc/patterns/crosscutting/issue-list.adoc
+++ b/src/main/asciidoc/patterns/crosscutting/issue-list.adoc
@@ -26,7 +26,7 @@ As always: documentation is only valuable if it can be found easily, which makes
 
 For every entry in this issue list we need to <<Estimate-Issue-Cost>>, an estimation of the cost of this issued in any business-related unit. 
 
-In case you already have identified or developed <<opportunities-for-improvement>> adressing this issue,
+In case you already have identified or developed <<Collect-Opportunities-For-Improvement,opportunities for improvement>> adressing this issue,
 links to the corresponding improvements (remedies, tactics, strategies, changes) in the
 <<Improvement-Backlog>> are neccesssary.
 

--- a/src/main/asciidoc/patterns/crosscutting/plan-improvement.adoc
+++ b/src/main/asciidoc/patterns/crosscutting/plan-improvement.adoc
@@ -4,5 +4,5 @@
 Conduct long- and short-term planning of improvement activities. Balance
 or align issues and improvements, considering existing goals and constraints.
 
-Consists of long-term decisions (concerning <<improve-approaches>>) and
+Consists of long-term decisions (concerning <<improve-approaches-overview>>) and
 short-term planning.

--- a/src/main/asciidoc/patterns/improve/Measure.adoc
+++ b/src/main/asciidoc/patterns/improve/Measure.adoc
@@ -30,10 +30,10 @@ This pattern should always be considered.
 
 ===== Related Patterns
 
-* This pattern is an important enabler for a successful <<Runtime-Artifact-Analysis>> or 
-<<Performance-Analysis>>.
-* <<Instrument-System>> and <<Profiling>> are very similar to this pattern, however they are limited to a temporary instrumentation that is needed during the Analysis phase to identify or scope a certain problem that cannot be isolated without modifying the code. 
+* This pattern is an important enabler for a successful <<Runtime-Artifact-Analysis>> or performance analysis.
+* <<Instrument-System>> and https://en.wikipedia.org/wiki/Profiling_(computer_programming)[profiling] are very similar to this pattern, however they are limited to a temporary instrumentation that is needed during the Analysis phase to identify or scope a certain problem that cannot be isolated without modifying the code.
 
 ===== References
 
-https://www.youtube.com/watch?v=czes-oa0yik[Coda Hale Talk on "Metrics-Everywhere"]
+* https://www.youtube.com/watch?v=czes-oa0yik[Coda Hale Talk on "Metrics-Everywhere"]
+

--- a/src/main/asciidoc/patterns/improve/Use-Invariants-To-Kill-Zombies.adoc
+++ b/src/main/asciidoc/patterns/improve/Use-Invariants-To-Kill-Zombies.adoc
@@ -21,7 +21,7 @@ munches on everybody's brain when it is time for the next system-wide change.
 
 This kind of zombie can be killed more safely by employing invariants. 
 
-An <<invariant>> -- as described by Bertrand Meyer in
+An invariant -- as described by Bertrand Meyer in
 <<Object-Oriented-Software-Construction>> -- is a logical expression that always
 is true for a given set of circumstances. He proposes to actually verify those
 invariants _in the code itself_. What happens if the invariant does not hold
@@ -95,7 +95,6 @@ weight of the system.
 * Invariants (and other <<Assertions>>) have been made popular by Bertrand Meyer
   in his seminal book <<Object-Oriented-Software-Construction>>
 * Brian Foote references Zombie code in <<Big-Ball-Of-Mud>>
-* Dead code is an alternate name for the lava-flow anti pattern in
-  <<AntiPatterns>>.
+* Dead code is an alternate name for the lava-flow anti pattern <<Brown>>.
 
 // end of list

--- a/src/main/asciidoc/patterns/improve/big-bang-approach.adoc
+++ b/src/main/asciidoc/patterns/improve/big-bang-approach.adoc
@@ -98,7 +98,7 @@ A big bang approach is possible, if you cannot or want to incrementally replace 
 
 * The new system should undergo a revolutionary improvement instead an incremental one for both, technology and functionality
 * The system is small enough that it can be rewritten quickly within a few month
-* You analyzed other approaches like <<Strangler Approach>> or
+* You analyzed other approaches like <<strangler-approach>> or
   https://www.amazon.com/Working-Effectively-Legacy-Michael-Feathers/dp/0131177052/ref=sr_1_1?s=books&ie=UTF8&qid=1478609966&sr=1-1&keywords=Working+Effectively+with+Legacy+Code[Seams]
   and they could not help you approaching the problem incrementally
 * You and your stakeholders are aware and understand the risks and consequences of a big bang rewrite and want to go for

--- a/src/main/asciidoc/patterns/improve/butterfly-methodology.adoc
+++ b/src/main/asciidoc/patterns/improve/butterfly-methodology.adoc
@@ -32,7 +32,7 @@ image::improve-approaches/butterfly.png["Butterfly-Methodology", title="Butterfl
 ===== Risks
 If the Butterfly Method will be successful depends on the factor v / u,
 where u is the speed of the Chrysalizer and v the speed of the DAA to setup new temp stores.
-If v = 0 this approach is similar to the <<Big-Bang Strategy>>, if v > u the migration will never end.
+If v = 0 this approach is similar to the <<big-bang-approach>>, if v > u the migration will never end.
 
 
 ===== Applicability
@@ -55,7 +55,7 @@ Critical success factors are:
 
 ===== Related Patterns
 
-* <<Chicken-Little Strategy>>
+* <<Chicken-Little-Strategy>>
 
 
 ===== References

--- a/src/main/asciidoc/patterns/improve/chicken-little-strategy.adoc
+++ b/src/main/asciidoc/patterns/improve/chicken-little-strategy.adoc
@@ -1,4 +1,4 @@
-[[chicken-little-strategy]]
-==== [pattern]#Chicken-Little Strategy#
+[[Chicken-Little-Strategy]]
+==== [pattern]#Chicken-Little-Strategy#
 
 to be completed...

--- a/src/main/asciidoc/patterns/improve/composite-database-approach.adoc
+++ b/src/main/asciidoc/patterns/improve/composite-database-approach.adoc
@@ -72,7 +72,7 @@ Information System architecture.
 
 ===== Related Patterns
 
-* <<Chicken-Little Strategy>>
+* <<Chicken-Little-Strategy>>
 
 ===== References
 

--- a/src/main/asciidoc/patterns/improve/database-first-approach.adoc
+++ b/src/main/asciidoc/patterns/improve/database-first-approach.adoc
@@ -57,7 +57,7 @@ legacy system can be shut down.
 
 ===== Related Patterns
 
-* <<Chicken-Little Strategy>>
+* <<Chicken-Little-Strategy>>
 
 ===== References
 

--- a/src/main/asciidoc/patterns/improve/database-last-approach.adoc
+++ b/src/main/asciidoc/patterns/improve/database-last-approach.adoc
@@ -64,7 +64,7 @@ may be unacceptable
 
 ===== Related Patterns
 
-* <<Chicken-Little Strategy>>
+* <<Chicken-Little-Strategy>>
 
 ===== References
 

--- a/src/main/asciidoc/patterns/improve/introduce-boy-scout-rule.adoc
+++ b/src/main/asciidoc/patterns/improve/introduce-boy-scout-rule.adoc
@@ -20,7 +20,7 @@ TIP: Often the introduction of concepts like layering is deemed _â€œimpossibleâ€
 
 ===== Description
 
-* Drafting from an <<improvement-backlog>>, define a specific rule set
+* Drafting from an <<Improvement-Backlog>>, define a specific rule set
   on how to improve the contents of specific file types.
 
 * Specify how much effort should be allowed to perform each specific
@@ -32,7 +32,7 @@ TIP: Often the introduction of concepts like layering is deemed _â€œimpossibleâ€
 
 * Install a mechanism to ensure that the things that where too big to
   be cleaned up while visiting the file will end up in the
-  <<improvement-backlog>>.
+  <<Improvement-Backlog>>.
 
 .Example Boy Scout Rule agreement
 
@@ -69,11 +69,10 @@ Item.COMPOUND_ITEMS_THRESHHOLD)+
 ===== Experiences
 
 Introducing the Boy Scout Rule on a heavily deteriorated code base
-induces heavy payback on <<technical-debt>> and often gets challenged
+induces heavy payback on https://en.wikipedia.org/wiki/Technical_debt[technical debt] and often gets challenged
 by team members and senior management. It is important to point out
-that the extended time spent on fixing the artifacts "`as the teams
-goes`" actually is the _explicit_ payment of the <<technical-debt>>
-interest rate.
+that the extended time spent on fixing the artifacts "as the teams
+goes" actually is the _explicit_ payment of the technical debt interest rate.
 
 ===== Risks
 
@@ -111,7 +110,7 @@ parts of the system other approaches have to be utilized.
 * <<Refactoring-Plan>>, as an alternative or complimenting approach
 * <<Introduce-Layering>> can be performed using the Boy Scout Rule
 * <<Anticorruption-Layer>> can be performed using the Boy Scout Rule
-* An <<improvement-backlog>> should be the basis for the tasks
+* An <<Improvement-Backlog>> should be the basis for the tasks
   performed when applying the Boy Scout Rule
 
 ===== References

--- a/src/main/asciidoc/patterns/improve/isolate-core-domain.adoc
+++ b/src/main/asciidoc/patterns/improve/isolate-core-domain.adoc
@@ -6,7 +6,7 @@
 
 ===== Description
 
-Rewriting an old system "big bang" is a risky endeavour. It is harder than you think (see "Big Bang Approach" in aim42).
+Rewriting an old system "big bang" is a risky endeavour. It is harder than you think (see <<big-bang-approach>>).
 
 An alternative route is to gradually create a new system around the edges of the old, letting it grow slowly over
 several years until the old system is strangled. The most important reason to consider a strangler application over a

--- a/src/main/asciidoc/patterns/improve/strangler-approach.adoc
+++ b/src/main/asciidoc/patterns/improve/strangler-approach.adoc
@@ -6,7 +6,7 @@ Divide a legacy system into different functional domains and replace those step 
 
 ===== Description
 
-Rewriting an old system with the <<Big Bang Approach>> is a risky endeavor. It is harder than you might think at the beginning.
+Rewriting an old system with the <<big-bang-approach>> is a risky endeavor. It is harder than you might think at the beginning.
 
 An alternative way is to gradually create a new system around the edges of the old, letting it grow slowly over
 several years until the old system is strangled. The most important reason to consider a strangler application over a


### PR DESCRIPTION
### Fixes bug in bibliography section
It seems that the upgrade of the asciidoctor-gradle-plugin from version 1.5.3 to 1.5.6 led to problems with the representation of the references in the bibliography section. The id texts between the square brackets were missing:

HTML output version 1.5.3 (OK):

![grafik](https://user-images.githubusercontent.com/1470822/48254189-99255780-e409-11e8-9de4-f7633f6109bb.png)

HTML output version 1.5.6 (Not OK):

![grafik](https://user-images.githubusercontent.com/1470822/48254211-a5111980-e409-11e8-8af6-d07d2dbdc0ad.png)

The reordering of the special section tags fixed that problem.

### Making HTML Sanity Checker happy again
Fixed all kinds of alts, references and links. I also updated the Graffle files. Now only one pattern ("Goals-Constraints") is missing.

### Minor content changes that were needed
* Added description for "Deprecate Obsolete Parts" pattern
* Added "Runtime Artifact Analysis" pattern
* Changed missing link to "Architecture-Documentation" to new "Doc-As-Code" content in section "View-Based Understanding"